### PR TITLE
Override: remove register links from various templates

### DIFF
--- a/templates/login-sidebar.html
+++ b/templates/login-sidebar.html
@@ -1,0 +1,14 @@
+## mako
+<%! from django.utils.translation import ugettext as _ %>
+
+## Replace the contents of login-sidebar
+<%block name="login_sidebar_content">
+  <div class="cta cta-help">
+    <h3>${_("Need Help?")}</h3>
+    <p>${_("Looking for help in logging in or with your {platform_name} account?").format(platform_name=platform_name)}
+    <a href="https://support.enthought.com/entries/30797510-Welcome-to-Enthought-Training-on-Demand"
+       target="_blank">
+        ${_("View our help section for answers to commonly asked questions.")}
+    </a></p>
+  </div>
+</%block>

--- a/templates/theme-header.html
+++ b/templates/theme-header.html
@@ -5,6 +5,11 @@
 
 ## TODO: this will eventually be moved to the Sass
 <%block name="navigation_logo">
-  <img src="${static.url('themes/enthought/images/ETOD-logo-blue-grey.png')}" height="50" alt="Home Page" />
+  <img src="${static.url('themes/enthought/images/ETOD-logo-blue-grey.png')}" height="50" alt="Enthought Training" />
 </%block>
 
+## Register link removed -- overriding the nav_global_register_link block
+## in navigation.html template located at edx-platform/lms/templates/
+##
+## REGISTER BUTTONS ARE NOT REQUIRED FOR ENTHOUGHT'S TRAINING PILOT PROJECT
+<%block name="nav_global_register_link" />


### PR DESCRIPTION
Depends on changes in commit
https://github.com/enthought/edx-platform/commit/7e3b811c8d9ce1e2004cbf94bfabe0d47be27c05
in the enthought/edx-platform repo.

@agrawalprash : I'm still checking for more links that might need removing from the templates; may add a couple of commits to this PR. Will ping you again when done. Thanks!
